### PR TITLE
Change CF EntryPoint

### DIFF
--- a/data/cloudformation-template.json
+++ b/data/cloudformation-template.json
@@ -165,7 +165,7 @@
             "EntryPoint": [
               "/bin/sh",
               "-c",
-              "mkdir config && echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - https://raw.githubusercontent.com/api3dao/api-integrations/main/data/apis/<API_ALIAS>/deployments/<DEPLOYMENT_TYPE>-deployments/<FILE_NAME> >> ./config/airnode-feed.json && node dist/src/index.js"
+              "mkdir config && echo -e $SECRETS_ENV >> ./config/secrets.env && wget -O - https://raw.githubusercontent.com/api3dao/api-integrations/main/data/apis/<API_ALIAS>/deployments/<DEPLOYMENT_TYPE>-deployments/<FILE_NAME> >> ./config/airnode-feed.json || wget -O - https://raw.githubusercontent.com/api3dao/api-integrations/main/data/apis/<API_ALIAS>/deployments/active-deployments/<FILE_NAME> >> ./config/airnode-feed.json && node dist/src/index.js"
             ],
             "LogConfiguration": {
               "LogDriver": "awsfirelens",

--- a/frontend/src/Helpers/DownloadConfig.js
+++ b/frontend/src/Helpers/DownloadConfig.js
@@ -183,7 +183,7 @@ const downloadCloudFormation = (CloudFormation, configData, airnodeAddress) => {
   const interpolationValues = [configData.apiProvider, configData.category, configData.filename];
   let entryPointBashCmd = CloudFormation.Resources.AppDefinition.Properties.ContainerDefinitions[1].EntryPoint[2];
   interpolationKeys.forEach((k, index) => {
-    entryPointBashCmd = entryPointBashCmd.replace(k, interpolationValues[index]);
+    entryPointBashCmd = entryPointBashCmd.replaceAll(k, interpolationValues[index]);
   });
 
   // Interpolate "LogConfiguration"


### PR DESCRIPTION
Closes https://github.com/api3dao/tasks/issues/704

The issue [here ](https://github.com/api3dao/signed-api/issues/207)was during the first deployment, the CF template was looking here `data/apis/nodary/deployments/candidate-deployments` and it was okay since the config was there. But after the deployment we move the candidate deployment config to `data/apis/nodary/deployments/active-deployments`. So, when Airnode feed was terminated and AWS tried to deploy the same template, but file was in `active-deployments`.