### PR TITLE
Increase slack time in deployment checker CI script

### DIFF
--- a/src/ci-scripts/check-deployment-status.ts
+++ b/src/ci-scripts/check-deployment-status.ts
@@ -85,7 +85,7 @@ export const stringifyUnsignedHeartbeatPayload = (unsignedHeartbeatPayload: Omit
 const createHash = (value: string) => ethers.utils.keccak256(ethers.utils.toUtf8Bytes(value));
 
 const ONE_MINUTE_IN_SECONS = 60;
-const SLACK = 1;
+const SLACK = 5;
 
 async function main() {
   const issues: any[] = [];


### PR DESCRIPTION
Closes https://github.com/api3dao/tasks/issues/733

The script compares the last heartbeat timestamp to the current time. Due to some delay occurring in the API call to the heartbeat endpoint, the initial slack time (1 second) was not enough so I increased it.

