### PR TITLE
Add a script to validate Airnode feed version

### DIFF
--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -34,6 +34,8 @@ jobs:
         run: pnpm validate-frontend
       - name: Validate APIs Folder
         run: pnpm validate-apis-folder
+      - name: Check Airnode feed version
+        run: pnpm check-airnode-feed-version
       - name: Validate Generated Files
         run: pnpm validate-generated-files
       - name: Run unit tests

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,4 +8,5 @@ echo "Done."
 echo "Checking generated files..."
 pnpm validate-generated-files
 pnpm check-deployment-status
+pnpm check-airnode-feed-version
 echo "Done."

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "validate-apis-folder": "ts-node src/ci-scripts/check-api-files-integrity.ts",
     "validate-generated-files": "ts-node src/ci-scripts/check-generated-files.ts",
     "check-deployment-status": "ts-node src/ci-scripts/check-deployment-status.ts",
+    "check-airnode-feed-version": "ts-node src/ci-scripts/check-airnode-feed-version.ts",
     "generate-airnode-feed-deployment": "ts-node src/config-generation/airnode-feed/generate-deployment.ts",
     "prepare": "husky install",
     "test:unit": "jest ./test/unit --silent=false",

--- a/src/ci-scripts/check-airnode-feed-version.ts
+++ b/src/ci-scripts/check-airnode-feed-version.ts
@@ -1,0 +1,37 @@
+import { nodeSettingsSchema } from '@api3/airnode-feed';
+import { readJson } from '../config-generation/config-utils';
+
+function main() {
+  const issues = [];
+  const DUMMY_MNEMONIC = 'online success junior focus title gauge timber old silk cereal kidney drip';
+
+  const boilerplateConfig = readJson('./boilerplates/boilerplate-airnode-feed-config.json');
+  boilerplateConfig.nodeSettings.airnodeWalletMnemonic = DUMMY_MNEMONIC;
+  boilerplateConfig.nodeSettings.stage = 'aws';
+
+  // check if generated configs will be created with correct nodeVersion
+  try {
+    nodeSettingsSchema.parse(boilerplateConfig.nodeSettings);
+  } catch (error) {
+    issues.push(`Possible nodeVersion mismatch in boilerplate configuration file. Error: ${error}`);
+  }
+
+  // check if CloudFormation template has the correct version
+  const CFTemplate = readJson('./data/cloudformation-template.json');
+  const imageName = CFTemplate.Resources.AppDefinition.Properties.ContainerDefinitions[1].Image;
+  const regex = /\d+\.\d+\.\d+/;
+  const imageVersion = imageName.match(regex)[0];
+
+  boilerplateConfig.nodeSettings.nodeVersion = imageVersion;
+  try {
+    nodeSettingsSchema.parse(boilerplateConfig.nodeSettings);
+  } catch (error) {
+    issues.push(`Possible nodeVersion mismatch in CloudFormation template. Error: ${error}`);
+  }
+
+  if (issues.length > 0) {
+    throw Error(JSON.stringify(issues, null, 2));
+  }
+}
+
+main();


### PR DESCRIPTION
Closes https://github.com/api3dao/api-integrations/issues/171

There are two files in the repository where we set the Airnode feed version manually, the CloudFormation template and the boilerplate configuration file. This script extracts the version from those files, puts the version to the `nodeSettings` object, and tries to parse the object using the current Airnode feed package's config schema.