### PR TITLE
Update airnode feed version

### DIFF
--- a/boilerplates/boilerplate-airnode-feed-config.json
+++ b/boilerplates/boilerplate-airnode-feed-config.json
@@ -1,7 +1,7 @@
 {
   "nodeSettings": {
     "airnodeWalletMnemonic": "${WALLET_MNEMONIC}",
-    "nodeVersion": "0.5.1",
+    "nodeVersion": "0.7.1",
     "stage": ""
   },
   "templates": {},

--- a/data/cloudformation-template.json
+++ b/data/cloudformation-template.json
@@ -106,7 +106,7 @@
           },
           {
             "Name": "AirnodeFeed",
-            "Image": "api3/airnode-feed:0.5.1",
+            "Image": "api3/airnode-feed:0.7.1",
             "Environment": [
               {
                 "Name": "SECRETS_ENV",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@api3/airnode-feed": "0.5.1",
+    "@api3/airnode-feed": "0.7.1",
     "@api3/commons": "^0.8.0",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: 3.22.4
     devDependencies:
       '@api3/airnode-feed':
-        specifier: 0.5.1
-        version: 0.5.1(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
+        specifier: 0.7.1
+        version: 0.7.1(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
       '@api3/commons':
         specifier: ^0.8.0
         version: 0.8.0(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
@@ -316,15 +316,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@api3/airnode-feed@0.5.1(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-ic0pkeEaYZOKKn28kU9iXpKJp4fub/qC6r68DY3vc1tK6ucZ6CJiNwW93dt6ZQeLMjFL6v3uIbwbNxeYZE8LHQ==}
-    engines: {node: '>=18.19.0'}
+  /@api3/airnode-feed@0.7.1(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-iZGkxSIQA3Aq3LH9TxN5S8VvH9VY87sLBBa8xBdrAE2Ao9hAyAXpEkF6+PdneGZa1cI953LEyUGU2ri0CuYa9g==}
+    engines: {node: '>=18.19.1'}
     dependencies:
       '@api3/airnode-abi': 0.14.0
       '@api3/airnode-adapter': 0.14.0
       '@api3/airnode-node': 0.14.0(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
       '@api3/airnode-validator': 0.14.0
-      '@api3/commons': 0.6.2(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
+      '@api3/commons': 0.7.1(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3)
       '@api3/ois': 2.3.2
       '@api3/promise-utils': 0.4.0
       axios: 1.6.7
@@ -480,8 +480,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@api3/commons@0.6.2(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-IBR9WAcbglFdMyehiv3MWFVK1jKv2jAao6tU2DcUmMztea0H+Nn9xAomHCwAlg7mTNn3qk7ZpWosZNGZjfeSTw==}
+  /@api3/commons@0.7.1(eslint@8.57.0)(jest@29.7.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-Cm2OfuLklEffSh2/DFnfyOBpa/JC3mXi4Xx0MUVZU8aqcGkc62bD3CqLXRXHEsxe2IQLg3B4NZhOZeNEWFl0nQ==}
     engines: {node: ^18.14.0 || ^20.10.0, pnpm: ^8.8.0}
     peerDependencies:
       eslint: ^8.50.0
@@ -490,6 +490,8 @@ packages:
       '@api3/promise-utils': 0.4.0
       '@typescript-eslint/eslint-plugin': 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 6.20.0(eslint@8.57.0)(typescript@5.3.3)
+      axios: 1.6.7
+      dotenv: 16.4.5
       eslint: 8.57.0
       eslint-config-next: 13.5.6(eslint@8.57.0)(typescript@5.3.3)
       eslint-plugin-check-file: 2.6.2(eslint@8.57.0)
@@ -512,6 +514,7 @@ packages:
       zod: 3.22.4
     transitivePeerDependencies:
       - bufferutil
+      - debug
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - jest

--- a/src/ci-scripts/check-deployment-status.ts
+++ b/src/ci-scripts/check-deployment-status.ts
@@ -8,6 +8,7 @@ import { readdirSync } from 'fs';
 import { ethers } from 'ethers';
 import { globSync } from 'glob';
 import axios from 'axios';
+import { createSha256Hash, serializePlainObject } from '@api3/commons';
 import { readJson } from '../config-generation/config-utils';
 import { apiDataSchema } from '../types';
 
@@ -21,6 +22,10 @@ export interface HeartbeatPayload {
   signature: string;
 }
 
+const semanticToNumber = (version: string) => {
+  return parseInt(version.replaceAll('.', ''));
+};
+
 async function checkDeployments(deployments: any[], apiName: string, apiData: any, deploymentType: string) {
   apiData = apiDataSchema.parse(apiData);
 
@@ -28,8 +33,15 @@ async function checkDeployments(deployments: any[], apiName: string, apiData: an
   await Promise.all(
     deployments.map(async (deploymentJson) => {
       let nDeployment = 0;
-      const configHash = createHash(JSON.stringify(deploymentJson));
+      let configHash: string;
       const deploymentStatus: HeartbeatPayload[] = await getDeploymentStatus(apiData.airnode);
+      const deploymentVersion = deploymentJson.nodeSettings.nodeVersion;
+      // calculate configHash based on the Airnode feed config version
+      if (semanticToNumber(deploymentVersion) < 600) {
+        configHash = createHash(JSON.stringify(deploymentJson));
+      } else {
+        configHash = createSha256Hash(serializePlainObject(deploymentJson));
+      }
 
       const targetDeploymentStatuses = deploymentStatus.filter(
         (targetDeploymentStatus) => targetDeploymentStatus.configHash === configHash
@@ -52,9 +64,12 @@ async function checkDeployments(deployments: any[], apiName: string, apiData: an
             deploymentTimestamp: targetDeploymentStatus.deploymentTimestamp,
             configHash: targetDeploymentStatus.configHash
           };
-          const message = ethers.utils.arrayify(
-            createHash(stringifyUnsignedHeartbeatPayload(unsignedHeartbeatPayload))
-          );
+          let message: Uint8Array;
+          if (semanticToNumber(deploymentVersion) < 600) {
+            message = ethers.utils.arrayify(createHash(stringifyUnsignedHeartbeatPayload(unsignedHeartbeatPayload)));
+          } else {
+            message = ethers.utils.arrayify(createSha256Hash(serializePlainObject(unsignedHeartbeatPayload)));
+          }
           const signatureResult = ethers.utils.verifyMessage(message, targetDeploymentStatus.signature);
           if (apiData.airnode !== signatureResult) {
             issues.push(`🔴 ${apiName}/${deploymentType} - Couldn't verify heartbeat signature!`);

--- a/src/ci-scripts/check-deployment-status.ts
+++ b/src/ci-scripts/check-deployment-status.ts
@@ -40,6 +40,8 @@ async function checkDeployments(deployments: any[], apiName: string, apiData: an
       if (semanticToNumber(deploymentVersion) < 600) {
         configHash = createHash(JSON.stringify(deploymentJson));
       } else {
+        // Airnode feed 0.6.0 and 0.7.0's config hash derivation is broken so
+        // below line should capture only the deployments >= 0.7.1
         configHash = createSha256Hash(serializePlainObject(deploymentJson));
       }
 


### PR DESCRIPTION
Closes https://github.com/api3dao/api-integrations/issues/197

This PR changes the deployment checker script for the new config hash derivation that the Airnode feed uses. 

There are still required changes in [/backend](https://github.com/api3dao/api-integrations/blob/8072d37ffb8dba990574121039e8030411b47a2c/backend/src/process-logs.ts#L34) since it verifies the heartbeats. The ~config hash should be generated~ heartbeat signature should be verified based on the version of the Airnode feed that sends the heartbeat so the `/backend` can support Airnode feed versions lower than `0.6.0`. - @bdrhn9 for visibility.